### PR TITLE
Installation from conda-forge instead of pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ FDAT enables to:
    conda env create -f environment.yml
    ```
 
-Note: If you already have a conda environment with the name `fdat`, step 4 will fail with an error. In this case, open the file `environment.yml` with a text editor and change `fdat` in the first line with a different name (e.g., `fdat2`). Afterwards, do step 4 above again. Please note that you also need to use this new name in step 2 of [Running](https://github.com/jgieseler/FDAT#running) below! 
+Note: If you already have a conda environment with the name `fdat`, step 4 will fail with an error. In this case, open the file `environment.yml` with a text editor and replace `fdat` in the first line with a different name (e.g., `fdat2`). Afterwards, do step 4 above again. You also need to use this new name in step 2 of [Running](https://github.com/jgieseler/FDAT#running) below! 
 
 ### Running
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,23 @@ FDAT enables to:
 
 ## Installation
 
-1. This tool requires a recent Python (>=3.10) installation. [We recommend installing Python via miniforge.](https://conda-forge.org/download/)
-2. [Download this file](https://github.com/spearhead-he/FDAT/archive/refs/heads/main.zip) and extract to a folder of your choice (or clone the repository [https://github.com/spearhead-he/FDAT](https://github.com/spearhead-he/FDAT) if you know how to use `git`).
-3. Open a terminal or the miniforge prompt and move to the directory extracted in step 2.
-4. Create a new virtual environment (e.g., `conda create --name fdat python=3.12`) and activate it (e.g., `conda activate fdat`).
-5. Install the Python dependencies from the *requirements.txt* file with `pip install -r requirements.txt` within the virtual environment.
-6. Start the tool by running `python FDAT_main.py`
+1. This tool requires a recent Python (>=3.10) installation. [We recommend installing Python via miniforge](https://conda-forge.org/download/) (this will give you the same `conda` command as if installing Anaconda).
+2. [Download this file](https://github.com/spearhead-he/FDAT/archive/refs/heads/main.zip) and extract to a folder of your choice. (Or clone the repository [https://github.com/spearhead-he/FDAT](https://github.com/spearhead-he/FDAT) with `git`).
+3. Open a terminal or miniforge prompt and move to the directory extracted in step 2.
+4. Create a new conda environment with all required dependencies by running:
+   ```
+   conda env create -f environment.yml
+   ```
+
+### Running
+
+1. Open a terminal or miniforge prompt and move to the directory created in [Installation](https://github.com/jgieseler/FDAT#installation) step 2.
+2. Activate the newly created environment with:
+   ```
+   conda activate fdat
+   ```
+3. Start the tool by running `python FDAT_main.py`
+
 
 ## Data Usage Instructions
 ### Example data

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ FDAT enables to:
 
 ## Installation
 
-1. This tool requires a recent Python (>=3.10) installation. [We recommend installing Python via miniforge/conda-forge.](https://conda-forge.org/download/)
+1. This tool requires a recent Python (>=3.10) installation. [We recommend installing Python via miniforge.](https://conda-forge.org/download/)
 2. [Download this file](https://github.com/spearhead-he/FDAT/archive/refs/heads/main.zip) and extract to a folder of your choice (or clone the repository [https://github.com/spearhead-he/FDAT](https://github.com/spearhead-he/FDAT) if you know how to use `git`).
 3. Open a terminal or the miniforge prompt and move to the directory extracted in step 2.
 4. Create a new virtual environment (e.g., `conda create --name fdat python=3.12`) and activate it (e.g., `conda activate fdat`).
 5. Install the Python dependencies from the *requirements.txt* file with `pip install -r requirements.txt` within the virtual environment.
-6. Start the tool by running `python3 FDAT_main.py`
+6. Start the tool by running `python FDAT_main.py`
 
 ## Data Usage Instructions
 ### Example data

--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ FDAT enables to:
 
 ## Installation
 
-```bash
-python3 -m pip install --upgrade pip setuptools
-pip3 install -r requirements.txt
-python3 FDAT_main.py
-```
+1. This tool requires a recent Python (>=3.10) installation. [We recommend installing Python via miniforge/conda-forge.](https://conda-forge.org/download/)
+2. [Download this file](https://github.com/spearhead-he/FDAT/archive/refs/heads/main.zip) and extract to a folder of your choice (or clone the repository [https://github.com/spearhead-he/FDAT](https://github.com/spearhead-he/FDAT) if you know how to use `git`).
+3. Open a terminal or the miniforge prompt and move to the directory extracted in step 2.
+4. Create a new virtual environment (e.g., `conda create --name fdat python=3.12`) and activate it (e.g., `conda activate fdat`).
+5. Install the Python dependencies from the *requirements.txt* file with `pip install -r requirements.txt` within the virtual environment.
+6. Start the tool by running `python3 FDAT_main.py`
 
 ## Data Usage Instructions
 ### Example data

--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ FDAT enables to:
 
 1. This tool requires a recent Python (>=3.10) installation. [We recommend installing Python via miniforge](https://conda-forge.org/download/) (this will give you the same `conda` command as if installing Anaconda).
 2. [Download this file](https://github.com/spearhead-he/FDAT/archive/refs/heads/main.zip) and extract to a folder of your choice. (Or clone the repository [https://github.com/spearhead-he/FDAT](https://github.com/spearhead-he/FDAT) with `git`).
-3. Open a terminal or miniforge prompt and move to the directory extracted in step 2.
+3. Open a terminal or miniforge prompt and move to the directory created in step 2.
 4. Create a new conda environment with all required dependencies by running:
    ```
    conda env create -f environment.yml
    ```
+
+Note: If you already have a conda environment with the name `fdat`, step 4 will fail with an error. In this case, open the file `environment.yml` with a text editor and change `fdat` in the first line with a different name (e.g., `fdat2`). Afterwards, do step 4 above again. Please note that you also need to use this new name in step 2 of [Running](https://github.com/jgieseler/FDAT#running) below! 
 
 ### Running
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,17 @@
+name: fdat
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - lmfit
+  - matplotlib
+  - numpy
+  - pandas
+  - pyqt
+  - pyqtgraph
+  - scipy
+  - scikit-learn
+  - xarray
+  - pip
+  - pip:
+    - spacepy


### PR DESCRIPTION
Changed installation to get most packages from conda-forge instead of pypi becauce PyQt5 sometimes has problems being installed with pip, but at least in my setup the installation from conda-forge worked. This also shortens the Installation instructions a bit (env creation & package installation becomes one step).