### PR TITLE
introduce PyQtDarkTheme

### DIFF
--- a/FDAT_main.py
+++ b/FDAT_main.py
@@ -6,6 +6,7 @@ import sys
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QApplication
+import qdarktheme
 
 # Set High DPI attributes BEFORE QApplication is created
 QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)
@@ -689,6 +690,9 @@ def main():
         
         # Now create the QApplication (High DPI attributes already set)
         app = QApplication(sys.argv)
+
+        # Apply PyQtDarkTheme auto selection. This provides a working "dark mode"
+        qdarktheme.setup_theme("auto")
         
         # Create settings manager first
         script_directory = os.path.dirname(os.path.abspath(__file__))

--- a/environment.yml
+++ b/environment.yml
@@ -14,4 +14,5 @@ dependencies:
   - xarray
   - pip
   - pip:
+    - pyqtdarktheme
     - spacepy

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ scikit-learn
 # GUI libraries
 PyQt5
 pyqtgraph
+pyqtdarktheme
 
 # Data loading and analysis
 pandas


### PR DESCRIPTION
This uses the `PyQtDarkTheme` package to provide a working "dark theme" for the GUI (will be selected automatically based on OS setting). At least on macOS otherwise some parts of the GUI are not visible in dark mode. 

[Note: there is some more text after the images!]

Dark mode before:
![Screenshot 2025-05-23 at 14 52 25](https://github.com/user-attachments/assets/cce0b9d2-3fd7-464b-a53f-a4eb335bf7c2)

Dark mode after:
![Screenshot 2025-05-23 at 14 52 48](https://github.com/user-attachments/assets/c4f94eb2-7331-41ea-8b46-f8be27715ecd)

Note that this also slightly changes the default "light theme".

Light mode (default) before:
<img width="795" alt="Screenshot 2025-05-22 at 11 35 48" src="https://github.com/user-attachments/assets/4eb5b664-bd64-4234-9eae-34a403b2fc9a" />

Light mode (default) after:
![Screenshot 2025-05-23 at 14 39 11](https://github.com/user-attachments/assets/c187d3c6-f686-4c1a-8271-4a1516a8ade6)

From a quick glance, it looks fine with those changes, and fixes the problems with dark mode. But I'm not sure if there has been some more thought on the current set-up.

